### PR TITLE
fix: err on missing local and global

### DIFF
--- a/lua/diagnosticls-configs/fs.lua
+++ b/lua/diagnosticls-configs/fs.lua
@@ -35,7 +35,7 @@ local get_local_exec = function(name, context)
   local binpath = string.format('%s/%s/%s', current_working_dir, local_bin_path, name)
 
   if vim.fn.filereadable(binpath) == 0 then
-    add_checkhealth_error(name)
+    return ''
   end
 
   return binpath


### PR DESCRIPTION
Proposed fix in ref to #29

Show error on `:checkhealth` only if local and global executable is missing for any specified tool.