### PR TITLE
fix(golangci_lint): add Severity to golangci_lint config

### DIFF
--- a/lua/diagnosticls-configs/linters/golangci_lint.lua
+++ b/lua/diagnosticls-configs/linters/golangci_lint.lua
@@ -12,6 +12,7 @@ return {
     line = 'Pos.Line',
     column = 'Pos.Column',
     message = '[golangci_lint] ${Text} [${FromLinter}]',
+    security = 'Severity',
   },
   rootPatterns = { '.git', 'go.mod' },
 }


### PR DESCRIPTION
I noticed that the `security` field was missing from the `golangci-lint` tool. Useful to have so that users can see different security levels in the linter messages 👌

Nice plug-in, thank you! Saved me a bunch of time 🙏 