### PR TITLE
Adds yamllint

### DIFF
--- a/lua/diagnosticls-configs/linters/yamllint.lua
+++ b/lua/diagnosticls-configs/linters/yamllint.lua
@@ -1,0 +1,20 @@
+local fs = require('diagnosticls-configs.fs')
+
+return {
+  sourceName = 'yamllint',
+  command = fs.executable('yamllint'),
+  debounce = 100,
+  args = {
+    '-f',
+    'parsable',
+    '%filepath'
+  },
+  formatPattern = {
+    [[^.*:(\d+):(\d+): \[(\w+)\] (.*)$]],
+    { line = 1, column = 2, security = 3, message = { '[yamllint]', 4 } }
+  },
+  securities = {
+    warning = 'warning',
+    error = 'error'
+  }
+}

--- a/lua/diagnosticls-configs/linters/yamllint.lua
+++ b/lua/diagnosticls-configs/linters/yamllint.lua
@@ -11,7 +11,7 @@ return {
   },
   formatPattern = {
     [[^.*:(\d+):(\d+): \[(\w+)\] (.*)$]],
-    { line = 1, column = 2, security = 3, message = { '[yamllint]', 4 } }
+    { line = 1, column = 2, security = 3, message = { '[yamllint] ', 4 } }
   },
   securities = {
     warning = 'warning',

--- a/supported-linters-and-formatters.md
+++ b/supported-linters-and-formatters.md
@@ -21,6 +21,7 @@ on how to set `default_config` check the docs:
 | Swift | [`swiftlint`](#swift) | |
 | TypeScript/TSX | [`eslint`](#typescript) | [`prettier`](#typescript) |
 | Vim | [`vint`](#vim) | |
+| YAML | [`yamllint`](#yaml) | |
 
 ## Linter/Formatter Configurations
 
@@ -338,6 +339,15 @@ local xo_fmt = require 'diagnosticls-configs.formatters.xo_fmt'
 local vint = require 'diagnosticls-configs.linters.vint'
 ```
 
+### YAML
+#### Linters
+
+[yamllint][yamllint]
+
+```lua
+local yamllint = require 'diagnosticls-configs.linters.yamllint'
+```
+
 [//]: # (Linters/Formatters list)
 [autopep8]: https://github.com/hhatto/autopep8
 [black]: https://github.com/psf/black
@@ -367,3 +377,4 @@ local vint = require 'diagnosticls-configs.linters.vint'
 [stylua]: https://github.com/JohnnyMorganz/StyLua
 [swiftformat]: https://github.com/nicklockwood/SwiftFormat
 [swiftlint]: https://github.com/realm/SwiftLint
+[yamllint]: https://github.com/adrienverge/yamllint

--- a/tests/diagnosticls-configs/linters_spec.lua
+++ b/tests/diagnosticls-configs/linters_spec.lua
@@ -23,6 +23,7 @@ describe('Linter Configurations -', function()
     'ts_standard',
     'vint',
     'xo',
+    'yamllint',
   }
 
   local function assert_config(config)


### PR DESCRIPTION
[yamllint](https://github.com/adrienverge/yamllint) is a linter for YAML files.
Added yamllint to documentation.
Added yamllint to tests.

Tested it locally:
<img width="1233" alt="Screen Shot 2023-01-18 at 01 24 32" src="https://user-images.githubusercontent.com/25568998/213099705-b1d829fe-be0f-4df4-96b9-fb4235128b67.png">
